### PR TITLE
Exit with error code on unknown scripts

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -54,5 +54,6 @@ switch (script) {
     console.log(
       'See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#updating-to-new-releases'
     );
+    process.exit(1);
     break;
 }


### PR DESCRIPTION
When asked to run an unknown script, indicate there was an error with
a non-zero exit code.
