### PR TITLE
Add moduleNameMapper to supported keys

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -62,6 +62,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'coverageReporters',
     'coverageThreshold',
     'snapshotSerializers',
+    'moduleNameMapper',
   ];
   if (overrides) {
     supportedKeys.forEach(key => {


### PR DESCRIPTION
Add moduleNameMapper to supported keys for overriding in createJestConfig.js in order to mock worker.js files to successfully run react-pdf tests through Jest. Related to this discussion https://github.com/wojtekmaj/react-pdf/issues/67.