### PR TITLE
Fix `Unexpected token <` error

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -349,6 +349,9 @@ module.exports = {
       navigateFallbackWhitelist: [/^(?!\/__).*/],
       // Don't precache sourcemaps (they're large) and build asset manifest:
       staticFileGlobsIgnorePatterns: [/\.map$/, /asset-manifest\.json$/],
+      // we are relying on older cached resources to be available throughout the page's lifetime
+      // because of async module loading
+      skipWaiting: false,
     }),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical


### PR DESCRIPTION
By default `skipWaiting` parameter is set to true, allowing newly
registered service worker to bypass the `waiting` state, so all out of
date cache entries from the previous service worker will be deleted.

Because of async dynamic module loading we don't want that to happen,
keeping a way of loading old chunks.

The downside of removing skipWaiting is that newly deployed
service worker code and caches won't become active until all existing
tabs that have an older version of that service worker are closed, but
that actually sounds we want exactly this behaviour. 

Related to
https://github.com/GoogleChromeLabs/sw-precache/issues/180#issuecomment-248386760

We can also provide users with a popup by click on which `skipWaiting()` will be called manually.

Any thoughts on this?