### PR TITLE
Enable babel-plugin-styled-components for development again

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -419,6 +419,7 @@ module.exports = function(webpackEnv) {
                       },
                     },
                   ],
+                  // enable better styled-components class names for development
                   !isEnvProduction &&
                     require.resolve('babel-plugin-styled-components'),
                 ].filter(Boolean),

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -419,7 +419,9 @@ module.exports = function(webpackEnv) {
                       },
                     },
                   ],
-                ],
+                  !isEnvProduction &&
+                    require.resolve('babel-plugin-styled-components'),
+                ].filter(Boolean),
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/
                 // directory for faster rebuilds.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -36,6 +36,7 @@
     "babel-jest": "^24.8.0",
     "babel-loader": "8.0.5",
     "babel-plugin-named-asset-import": "^0.3.2",
+    "babel-plugin-styled-components": "^1.10.6",
     "babel-preset-react-app": "^9.0.0",
     "camelcase": "^5.2.0",
     "case-sensitive-paths-webpack-plugin": "2.2.0",


### PR DESCRIPTION
This plugin has been removed during migration