### PR TITLE
Eslint: Emit warnings instead of errors during dev

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -336,6 +336,7 @@ module.exports = function(webpackEnv) {
           use: [
             {
               options: {
+                emitWarning: isEnvDevelopment, // Don't fail on eslint errors during development
                 formatter: require.resolve('react-dev-utils/eslintFormatter'),
                 eslintPath: require.resolve('eslint'),
                 resolvePluginsRelativeTo: __dirname,


### PR DESCRIPTION
It's so annoying that the build breaks during hot reloading, if there are eslint errors.
It breaks the development flow, and one ends up having to remove unused variables and such when experimenting.
Tools should improve development experience, not decrease it!